### PR TITLE
feat: implement PeerStore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ websocket = ["libp2p/websocket", "rcgen", "libp2p/websocket-websys"]
 webtransport = ["libp2p/webtransport-websys"]
 
 [workspace]
-members = ["examples/browser-webrtc", "examples/custom-behaviour-and-context", "examples/custom-transport", "examples/distributed-key-value-store", "examples/file-sharing", "examples/floodsub", "examples/gossipsub", "examples/ipfs-kad", "examples/relay", "examples/rendezvous", "examples/stream", "examples/upnp"]
+members = ["examples/browser-webrtc", "examples/custom-behaviour-and-context", "examples/custom-transport", "examples/distributed-key-value-store", "examples/file-sharing", "examples/floodsub", "examples/gossipsub", "examples/ipfs-kad", "examples/peer-store", "examples/relay", "examples/rendezvous", "examples/stream", "examples/upnp"]
 
 [workspace.dependencies]
 async-rt = "0.1.8"

--- a/examples/peer-store/Cargo.toml
+++ b/examples/peer-store/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "peer-store"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[package.metadata.release]
+release = false
+
+[dependencies]
+tokio.workspace = true
+futures.workspace = true
+connexa = { path = "../../", default-features = false, features = ["ed25519", "yamux", "noise"] }

--- a/examples/peer-store/src/main.rs
+++ b/examples/peer-store/src/main.rs
@@ -1,0 +1,59 @@
+use connexa::prelude::DefaultConnexaBuilder;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let connexa_a = DefaultConnexaBuilder::new_identity()
+        .with_peer_store()
+        .enable_memory_transport()
+        .build()?;
+
+    let id_a = connexa_a
+        .swarm()
+        .listen_on("/memory/0".parse().unwrap())
+        .await?;
+
+    let peer_a_id = connexa_a.keypair().public().to_peer_id();
+
+    let node_a_addrs = connexa_a.swarm().get_listening_addresses(id_a).await?;
+
+    let connexa_b = DefaultConnexaBuilder::new_identity()
+        .with_peer_store()
+        .enable_memory_transport()
+        .build()?;
+
+    let id_b = connexa_b
+        .swarm()
+        .listen_on("/memory/0".parse().unwrap())
+        .await?;
+
+    let peer_b_id = connexa_b.keypair().public().to_peer_id();
+
+    let node_b_addrs = connexa_b.swarm().get_listening_addresses(id_b).await?;
+
+    for addr in node_a_addrs {
+        connexa_b.peer_store().add_address(peer_a_id, addr).await?;
+    }
+
+    for addr in node_b_addrs {
+        connexa_a.peer_store().add_address(peer_b_id, addr).await?;
+    }
+
+    let addrs_a = connexa_b.peer_store().list(peer_a_id).await?;
+    let addrs_b = connexa_a.peer_store().list(peer_b_id).await?;
+
+    println!(
+        "Peer {} has addresses for {}: {:?}",
+        peer_b_id,
+        peer_a_id,
+        addrs_a.iter().map(|a| a.to_string()).collect::<Vec<_>>()
+    );
+
+    println!(
+        "Peer {} has addresses for {}: {:?}",
+        peer_a_id,
+        peer_b_id,
+        addrs_b.iter().map(|a| a.to_string()).collect::<Vec<_>>()
+    );
+
+    Ok(())
+}

--- a/src/behaviour.rs
+++ b/src/behaviour.rs
@@ -1,4 +1,5 @@
 pub mod dummy;
+mod peer_store;
 #[cfg(feature = "request-response")]
 pub mod request_response;
 #[cfg(feature = "request-response")]
@@ -41,6 +42,8 @@ pub struct Behaviour<C> {
     pub allow_list: Toggle<libp2p_allow_block_list::Behaviour<AllowedPeers>>,
     pub deny_list: Toggle<libp2p_allow_block_list::Behaviour<BlockedPeers>>,
     pub connection_limits: Toggle<libp2p_connection_limits::Behaviour>,
+
+    pub peer_store: Toggle<peer_store::Behaviour>,
 
     #[cfg(feature = "relay")]
     // networking
@@ -312,11 +315,17 @@ where
             })
             .into();
 
+        let peer_store = protocols
+            .peer_store
+            .then(|| peer_store::Behaviour::default())
+            .into();
+
         #[allow(unused_mut)]
         let mut behaviour = Behaviour {
             allow_list,
             deny_list,
             connection_limits,
+            peer_store,
             #[cfg(not(target_arch = "wasm32"))]
             #[cfg(feature = "mdns")]
             mdns,

--- a/src/behaviour.rs
+++ b/src/behaviour.rs
@@ -1,5 +1,5 @@
 pub mod dummy;
-mod peer_store;
+pub mod peer_store;
 #[cfg(feature = "request-response")]
 pub mod request_response;
 #[cfg(feature = "request-response")]

--- a/src/behaviour/peer_store.rs
+++ b/src/behaviour/peer_store.rs
@@ -1,5 +1,5 @@
-mod memory;
-mod store;
+pub mod memory;
+pub mod store;
 
 use crate::behaviour::peer_store::memory::MemoryStore;
 use crate::behaviour::peer_store::store::Store;

--- a/src/behaviour/peer_store.rs
+++ b/src/behaviour/peer_store.rs
@@ -1,0 +1,135 @@
+mod memory;
+mod store;
+
+use crate::behaviour::peer_store::memory::MemoryStore;
+use crate::behaviour::peer_store::store::Store;
+use crate::prelude::swarm::derive_prelude::PortUse;
+use crate::prelude::swarm::{
+    ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour, THandler, THandlerInEvent,
+    THandlerOutEvent, ToSwarm,
+};
+use crate::prelude::transport::Endpoint;
+use crate::prelude::{Multiaddr, PeerId};
+use futures::FutureExt;
+use futures::future::BoxFuture;
+use std::task::{Context, Poll, Waker};
+
+pub struct Behaviour<S = MemoryStore>
+where
+    S: 'static,
+{
+    store: S,
+    waker: Option<Waker>,
+}
+
+impl Default for Behaviour<MemoryStore> {
+    fn default() -> Self {
+        Self {
+            waker: None,
+            store: MemoryStore::default(),
+        }
+    }
+}
+
+impl<S> Behaviour<S>
+where
+    S: Store,
+{
+    pub fn new(store: S) -> Self {
+        Self { waker: None, store }
+    }
+
+    pub fn insert(
+        &mut self,
+        peer_id: PeerId,
+        address: Multiaddr,
+    ) -> BoxFuture<'static, std::io::Result<()>> {
+        self.store.insert(peer_id, address).boxed()
+    }
+    pub fn remove(
+        &mut self,
+        peer_id: &PeerId,
+    ) -> BoxFuture<'static, std::io::Result<Vec<Multiaddr>>> {
+        self.store.remove(peer_id).boxed()
+    }
+    pub fn remove_address(
+        &mut self,
+        peer_id: &PeerId,
+        address: &Multiaddr,
+    ) -> BoxFuture<'static, std::io::Result<()>> {
+        self.store.remove_address(peer_id, address).boxed()
+    }
+    pub fn address(&self, peer_id: &PeerId) -> BoxFuture<'static, std::io::Result<Vec<Multiaddr>>> {
+        self.store.address(peer_id).boxed()
+    }
+}
+
+impl<S> NetworkBehaviour for Behaviour<S>
+where
+    S: Store + 'static,
+{
+    type ConnectionHandler = super::dummy::DummyHandler;
+    type ToSwarm = S::Event;
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        _peer: PeerId,
+        _local_addr: &Multiaddr,
+        _remote_addr: &Multiaddr,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        Ok(super::dummy::DummyHandler)
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        _peer: PeerId,
+        _addr: &Multiaddr,
+        _role_override: Endpoint,
+        _port_use: PortUse,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        Ok(super::dummy::DummyHandler)
+    }
+
+    fn handle_pending_outbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        _maybe_peer: Option<PeerId>,
+        _addresses: &[Multiaddr],
+        _effective_role: Endpoint,
+    ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
+        let Some(peer_id) = _maybe_peer else {
+            return Ok(vec![]);
+        };
+
+        let addrs = self.store.in_memory_address(&peer_id);
+        Ok(addrs)
+    }
+
+    fn on_swarm_event(&mut self, event: FromSwarm) {
+        self.store.on_swarm_event(&event)
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        _: PeerId,
+        _: ConnectionId,
+        _: THandlerOutEvent<Self>,
+    ) {
+        todo!()
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+        match self.store.poll(cx) {
+            Poll::Ready(ev) => Poll::Ready(ToSwarm::GenerateEvent(ev)),
+            Poll::Pending => {
+                self.waker = Some(cx.waker().clone());
+                Poll::Pending
+            }
+        }
+    }
+}

--- a/src/behaviour/peer_store/memory.rs
+++ b/src/behaviour/peer_store/memory.rs
@@ -1,0 +1,177 @@
+use crate::behaviour::peer_store::store::Store;
+use crate::prelude::swarm::derive_prelude::ConnectionEstablished;
+use crate::prelude::swarm::{ConnectionClosed, FromSwarm, NewExternalAddrOfPeer};
+use futures::future::{Ready, ready};
+use futures::{FutureExt, StreamExt};
+use futures_timer::Delay;
+use indexmap::map::Entry;
+use indexmap::{IndexMap, IndexSet};
+use libp2p::swarm::ConnectionId;
+use libp2p::{Multiaddr, PeerId};
+use pollable_map::futures::FutureMap;
+use std::task::{Context, Poll};
+
+#[derive(Default)]
+pub struct MemoryStore {
+    peers: IndexMap<PeerId, IndexSet<Multiaddr>>,
+    // Note: we do this to act as a "reference counter" to the same address connected to the peer
+    //       before we proceed to mark the address for removal.
+    connections: IndexMap<PeerId, IndexMap<Multiaddr, IndexSet<ConnectionId>>>,
+    persistent: IndexSet<PeerId>,
+    timer: FutureMap<(PeerId, Multiaddr), Delay>,
+}
+
+// Note that we use this because the trait returns a future, which would allow the implementation to either use `async` to desugar to `fn -> impl Future`
+// or allow custom futures (ie here we use `Ready` since this is in-memory and is expected to be ready). This, however, may change in the future.
+// See https://github.com/rust-lang/rust/issues/121718 for more information
+#[allow(refining_impl_trait)]
+impl Store for MemoryStore {
+    type Event = ();
+
+    fn insert(&mut self, peer_id: PeerId, address: Multiaddr) -> Ready<std::io::Result<()>> {
+        let result = match self.peers.entry(peer_id).or_default().insert(address) {
+            true => {
+                self.persistent.insert(peer_id);
+                Ok(())
+            }
+            false => Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "address already exists",
+            )),
+        };
+        ready(result)
+    }
+
+    fn remove(&mut self, peer_id: &PeerId) -> Ready<std::io::Result<Vec<Multiaddr>>> {
+        let result = {
+            let list = self.peers.shift_remove(peer_id);
+            match list {
+                Some(list) => {
+                    self.persistent.shift_remove(peer_id);
+                    Ok(Vec::from_iter(list))
+                }
+                None => Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "peer not found",
+                )),
+            }
+        };
+        ready(result)
+    }
+
+    fn remove_address(
+        &mut self,
+        peer_id: &PeerId,
+        address: &Multiaddr,
+    ) -> Ready<std::io::Result<()>> {
+        if let Entry::Occupied(mut entry) = self.peers.entry(*peer_id) {
+            if entry.get_mut().shift_remove(address) {
+                return ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "address not found",
+                )));
+            }
+            if entry.get().is_empty() {
+                entry.shift_remove();
+                self.persistent.shift_remove(peer_id);
+            }
+            return ready(Ok(()));
+        }
+        ready(Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "peer not found",
+        )))
+    }
+
+    fn address(&self, peer_id: &PeerId) -> Ready<std::io::Result<Vec<Multiaddr>>> {
+        let Some(addrs) = self.peers.get(peer_id).cloned() else {
+            return ready(Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "peer not found",
+            )));
+        };
+        ready(Ok(Vec::from_iter(addrs)))
+    }
+
+    fn in_memory_address(&self, peer_id: &PeerId) -> Vec<Multiaddr> {
+        self.peers
+            .get(peer_id)
+            .cloned()
+            .map(Vec::from_iter)
+            .unwrap_or_default()
+    }
+
+    fn on_swarm_event(&mut self, event: &FromSwarm) {
+        match event {
+            FromSwarm::NewExternalAddrOfPeer(NewExternalAddrOfPeer { peer_id, addr }) => {
+                self.peers
+                    .entry(*peer_id)
+                    .or_default()
+                    .insert(Multiaddr::clone(addr));
+                self.persistent.insert(*peer_id);
+            }
+            FromSwarm::ConnectionEstablished(ConnectionEstablished {
+                peer_id,
+                connection_id,
+                endpoint,
+                failed_addresses: _,
+                ..
+            }) => {
+                // Note: because we are adding the addresses from an established connection, we will not be persisting the address unless
+                //       the address is added manually.
+                let remote_addr = endpoint.get_remote_address();
+                self.connections
+                    .entry(*peer_id)
+                    .or_default()
+                    .entry(remote_addr.clone())
+                    .or_default()
+                    .insert(*connection_id);
+                self.peers
+                    .entry(*peer_id)
+                    .or_default()
+                    .insert(remote_addr.clone());
+                // TODO: determine if we should remove any failed addresses from the store to keep the entry up to date?
+            }
+            FromSwarm::ConnectionClosed(ConnectionClosed {
+                connection_id,
+                peer_id,
+                endpoint,
+                ..
+            }) => {
+                let remote_addr = endpoint.get_remote_address();
+
+                if let Entry::Occupied(mut entry) = self.connections.entry(*peer_id) {
+                    let list = entry.get_mut();
+                    if let Entry::Occupied(mut ma_entry) = list.entry(remote_addr.clone()) {
+                        let connections = ma_entry.get_mut();
+                        connections.shift_remove(connection_id);
+                        if connections.is_empty() {
+                            ma_entry.shift_remove();
+                            self.timer.insert(
+                                (*peer_id, remote_addr.clone()),
+                                Delay::new(std::time::Duration::from_secs(60)),
+                            );
+                        }
+                    }
+                    if list.is_empty() {
+                        entry.shift_remove();
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Self::Event> {
+        while let Poll::Ready(Some(((peer_id, addr), _))) = self.timer.poll_next_unpin(cx) {
+            if let Err(e) = self
+                .remove_address(&peer_id, &addr)
+                .now_or_never()
+                .expect("future ready")
+            {
+                tracing::error!(%peer_id, %addr, error = %e, "failed to remove address from store");
+            }
+        }
+        Poll::Pending
+    }
+}

--- a/src/behaviour/peer_store/memory.rs
+++ b/src/behaviour/peer_store/memory.rs
@@ -21,6 +21,17 @@ pub struct MemoryStore {
     timer: FutureMap<(PeerId, Multiaddr), Delay>,
 }
 
+impl FromIterator<(PeerId, Multiaddr)> for MemoryStore {
+    fn from_iter<T: IntoIterator<Item = (PeerId, Multiaddr)>>(iter: T) -> Self {
+        let mut store = Self::default();
+        for (peer_id, addr) in iter {
+            store.persistent.insert(peer_id);
+            store.peers.entry(peer_id).or_default().insert(addr);
+        }
+        store
+    }
+}
+
 // Note that we use this because the trait returns a future, which would allow the implementation to either use `async` to desugar to `fn -> impl Future`
 // or allow custom futures (ie here we use `Ready` since this is in-memory and is expected to be ready). This, however, may change in the future.
 // See https://github.com/rust-lang/rust/issues/121718 for more information

--- a/src/behaviour/peer_store/store.rs
+++ b/src/behaviour/peer_store/store.rs
@@ -1,0 +1,32 @@
+use libp2p::swarm::FromSwarm;
+use libp2p::{Multiaddr, PeerId};
+use std::fmt::Debug;
+use std::task::{Context, Poll};
+
+pub trait Store: 'static {
+    type Event: Debug + Send;
+    fn insert(
+        &mut self,
+        peer_id: PeerId,
+        address: Multiaddr,
+    ) -> impl Future<Output = std::io::Result<()>> + Send + 'static;
+    fn remove(
+        &mut self,
+        peer_id: &PeerId,
+    ) -> impl Future<Output = std::io::Result<Vec<Multiaddr>>> + Send + 'static;
+    fn remove_address(
+        &mut self,
+        peer_id: &PeerId,
+        address: &Multiaddr,
+    ) -> impl Future<Output = std::io::Result<()>> + Send + 'static;
+    fn address(
+        &self,
+        peer_id: &PeerId,
+    ) -> impl Future<Output = std::io::Result<Vec<Multiaddr>>> + Send + 'static;
+
+    fn in_memory_address(&self, peer_id: &PeerId) -> Vec<Multiaddr>;
+
+    fn on_swarm_event(&mut self, event: &FromSwarm);
+
+    fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Self::Event>;
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -174,6 +174,7 @@ pub(crate) struct Protocols {
     pub(crate) connection_limits: bool,
     pub(crate) allow_list: bool,
     pub(crate) deny_list: bool,
+    pub(crate) peer_store: bool,
 }
 
 impl<B, Ctx, Cmd> ConnexaBuilder<B, Ctx, Cmd>
@@ -292,6 +293,12 @@ where
     {
         self.protocols.kad = true;
         self.config.kademlia_config = (protocol.into(), Box::new(f));
+        self
+    }
+
+    /// Enables peer store
+    pub fn with_peer_store(mut self) -> Self {
+        self.protocols.peer_store = true;
         self
     }
 

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -7,6 +7,7 @@ pub(crate) mod dht;
 pub(crate) mod floodsub;
 #[cfg(feature = "gossipsub")]
 pub(crate) mod gossipsub;
+mod peer_store;
 #[cfg(feature = "rendezvous")]
 pub(crate) mod rendezvous;
 #[cfg(feature = "request-response")]
@@ -25,6 +26,7 @@ use crate::handle::dht::ConnexaDht;
 use crate::handle::floodsub::ConnexaFloodsub;
 #[cfg(feature = "gossipsub")]
 use crate::handle::gossipsub::ConnexaGossipsub;
+use crate::handle::peer_store::ConnexaPeerstore;
 #[cfg(feature = "rendezvous")]
 use crate::handle::rendezvous::ConnexaRendezvous;
 #[cfg(feature = "request-response")]
@@ -139,6 +141,11 @@ where
     /// Returns a handle to manage peer blacklist functionality  
     pub fn blacklist(&self) -> ConnexaBlacklist<T> {
         ConnexaBlacklist::new(self)
+    }
+
+    /// Returns a handle to the peer store
+    pub fn peer_store(&self) -> ConnexaPeerstore<T> {
+        ConnexaPeerstore::new(self)
     }
 
     /// Keypair that was used during initialization

--- a/src/handle/peer_store.rs
+++ b/src/handle/peer_store.rs
@@ -1,0 +1,73 @@
+use crate::handle::Connexa;
+use crate::prelude::PeerId;
+use crate::types::PeerstoreCommand;
+use futures::channel::oneshot;
+use libp2p::Multiaddr;
+
+#[derive(Copy, Clone)]
+pub struct ConnexaPeerstore<'a, T = ()> {
+    connexa: &'a Connexa<T>,
+}
+
+impl<'a, T> ConnexaPeerstore<'a, T>
+where
+    T: Send + Sync + 'static,
+{
+    pub(crate) fn new(connexa: &'a Connexa<T>) -> Self {
+        Self { connexa }
+    }
+
+    pub async fn add_address(&self, peer_id: PeerId, addr: Multiaddr) -> std::io::Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.connexa
+            .to_task
+            .clone()
+            .send(
+                PeerstoreCommand::Add {
+                    peer_id,
+                    addr,
+                    resp: tx,
+                }
+                .into(),
+            )
+            .await?;
+        rx.await.map_err(std::io::Error::other)??.await
+    }
+
+    pub async fn remove_address(&self, peer_id: PeerId, addr: Multiaddr) -> std::io::Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.connexa
+            .to_task
+            .clone()
+            .send(
+                PeerstoreCommand::RemoveAddress {
+                    peer_id,
+                    addr,
+                    resp: tx,
+                }
+                .into(),
+            )
+            .await?;
+        rx.await.map_err(std::io::Error::other)??.await
+    }
+
+    pub async fn remove_peer(&self, peer_id: PeerId) -> std::io::Result<Vec<Multiaddr>> {
+        let (tx, rx) = oneshot::channel();
+        self.connexa
+            .to_task
+            .clone()
+            .send(PeerstoreCommand::Remove { peer_id, resp: tx }.into())
+            .await?;
+        rx.await.map_err(std::io::Error::other)??.await
+    }
+
+    pub async fn list(&self, peer_id: PeerId) -> std::io::Result<Vec<Multiaddr>> {
+        let (tx, rx) = oneshot::channel();
+        self.connexa
+            .to_task
+            .clone()
+            .send(PeerstoreCommand::List { peer_id, resp: tx }.into())
+            .await?;
+        rx.await.map_err(std::io::Error::other)??.await
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,10 @@ pub mod prelude {
         pub use libp2p::swarm::*;
     }
 
+    pub mod peer_store {
+        pub use crate::behaviour::peer_store::{memory, store};
+    }
+
     #[cfg(feature = "kad")]
     pub mod dht {
         pub use crate::handle::dht::{ToOptionalRecordKey, ToRecordKey};

--- a/src/types.rs
+++ b/src/types.rs
@@ -43,6 +43,7 @@ pub enum Command<T = ()> {
     Whitelist(WhitelistCommand),
     Blacklist(BlacklistCommand),
     ConnectionLimits(ConnectionLimitsCommand),
+    Peerstore(PeerstoreCommand),
     Custom(T),
 }
 
@@ -116,6 +117,12 @@ impl<T> From<BlacklistCommand> for Command<T> {
 impl<T> From<ConnectionLimitsCommand> for Command<T> {
     fn from(cmd: ConnectionLimitsCommand) -> Self {
         Command::ConnectionLimits(cmd)
+    }
+}
+
+impl<T> From<PeerstoreCommand> for Command<T> {
+    fn from(value: PeerstoreCommand) -> Self {
+        Command::Peerstore(value)
     }
 }
 
@@ -543,5 +550,27 @@ pub enum BlacklistCommand {
     },
     List {
         resp: oneshot::Sender<Result<Vec<PeerId>>>,
+    },
+}
+
+#[derive(Debug)]
+pub enum PeerstoreCommand {
+    Add {
+        peer_id: PeerId,
+        addr: Multiaddr,
+        resp: oneshot::Sender<Result<BoxFuture<'static, std::io::Result<()>>>>,
+    },
+    RemoveAddress {
+        peer_id: PeerId,
+        addr: Multiaddr,
+        resp: oneshot::Sender<Result<BoxFuture<'static, std::io::Result<()>>>>,
+    },
+    Remove {
+        peer_id: PeerId,
+        resp: oneshot::Sender<Result<BoxFuture<'static, std::io::Result<Vec<Multiaddr>>>>>,
+    },
+    List {
+        peer_id: PeerId,
+        resp: oneshot::Sender<Result<BoxFuture<'static, std::io::Result<Vec<Multiaddr>>>>>,
     },
 }


### PR DESCRIPTION
Currently, there is no peer store within connexa or within libp2p (at least not one that is active). This PR introduces a peerstore with a trait implementation so users can eventually implement their own storage. Currently, there is a memory store implementation that stores the peers in memory. The trait functions uses futures so that future implementations can return a future that is sent to the caller from `ConnexaPeerstore` so that it polls there while progress can continue to be made in the separate task.

Note: This PR does not allow custom stores and will default to the memory store for now. The next PR will handles that implementatino. 